### PR TITLE
made client's game chat limit messages to display to MAX_MESSAGES

### DIFF
--- a/modules/game/client/controllers/game.client.controller.js
+++ b/modules/game/client/controllers/game.client.controller.js
@@ -5,6 +5,7 @@ angular.module('game').controller('GameController', ['$scope', '$location', 'Aut
   function ($scope, $location, Authentication, Socket) {
     // Create a messages array
     $scope.messages = [];
+    var MAX_MESSAGES = 12; // maximum number of messages
 
     // If user is not signed in then redirect back home
     if (!Authentication.user) {
@@ -19,6 +20,11 @@ angular.module('game').controller('GameController', ['$scope', '$location', 'Aut
     // Add an event listener to the 'gameMessage' event
     Socket.on('gameMessage', function (message) {
       $scope.messages.unshift(message);
+
+      // delete old messages if MAX_MESSAGES is exceeded
+      if ($scope.messages.length > MAX_MESSAGES) {
+        $scope.messages.pop();
+      }
     });
 
     // Create a controller method for sending messages


### PR DESCRIPTION
Changed it so the game chat (not the chat chat) has a limit of 12 messages. This is arbitrary and can be set to anything really. Idea behind this is that when someone guesses the answer, other people won't be allowed to scroll up to try and deduce the answer from that person's close-but-not-yet-correct guesses. Also, chat history isn't really important for guesses anyway.
