### PR TITLE
Prevent empty messages from being sent

### DIFF
--- a/modules/game/client/controllers/game.client.controller.js
+++ b/modules/game/client/controllers/game.client.controller.js
@@ -10,6 +10,8 @@ angular.module('game').controller('GameController', ['$scope', '$location', 'Aut
     // Set default pen colour
     $scope.penColour = '#ff0000';
 
+    $scope.messageText = '';
+
     // If user is not signed in then redirect to signin page
     if (!Authentication.user) {
       $location.path('/authentication/signin');
@@ -87,16 +89,22 @@ angular.module('game').controller('GameController', ['$scope', '$location', 'Aut
 
     // Create a controller method for sending messages
     $scope.sendMessage = function () {
+      // Disallow empty messages
+      if (/^\s*$/.test($scope.messageText)) {
+        $scope.messageText = '';
+        return;
+      }
+
       // Create a new message object
       var message = {
-        text: this.messageText
+        text: $scope.messageText
       };
 
       // Emit a 'gameMessage' message event
       Socket.emit('gameMessage', message);
 
       // Clear the message text
-      this.messageText = '';
+      $scope.messageText = '';
     };
 
     // Returns true if we are currently the drawer and false otherwise

--- a/modules/game/client/views/game.client.view.html
+++ b/modules/game/client/views/game.client.view.html
@@ -41,7 +41,7 @@
       <form class="col-xs-12 col-md-12" ng-submit="sendMessage();">
         <fieldset class="row">
           <div class="input-group col-xs-12 col-md-12">
-            <input ng-disabled="isDrawer()" type="text" id="messageText" name="messageText" class="form-control" ng-model="messageText" placeholder="Enter new message">
+            <input ng-disabled="isDrawer()" type="text" id="messageText" name="messageText" class="form-control" ng-model="messageText" ng-trim="false" placeholder="Enter new message">
           </div>
         </fieldset>
       </form>


### PR DESCRIPTION
Added `ng-trim="false"`. This is because when trim is false, the ng-model value is set to `''` (empty string) even when the textbox is full of spaces. This means that when you do `$scope.messageText = ''` it seems like the model isn't changed and therefore the textbox is not cleared.
