### PR TITLE
Bugfix/erase blank

### DIFF
--- a/modules/game/client/directives/drawing.client.directives.js
+++ b/modules/game/client/directives/drawing.client.directives.js
@@ -104,7 +104,7 @@ angular.module('game').directive('dtDrawing', ['Socket', 'MouseConstants', 'Canv
 
           // If we started drawing within the canvas, draw the next part of the line
           if (drawingLeft) {
-            element.drawLine(e);
+            drawAndEmit(e);
           }
 
           // Redraw the preview layer to match the new position
@@ -133,8 +133,8 @@ angular.module('game').directive('dtDrawing', ['Socket', 'MouseConstants', 'Canv
           // If we released the left mouse button, stop drawing and finish the line
           if (e.which === MouseConstants.MOUSE_LEFT && drawingLeft) {
             drawingLeft = false;
-            // Final drawLine allows you to make a dot by clicking once and not moving mouse.
-            element.drawLine(e);
+            // Final drawAndEmit allows you to make a dot by clicking once and not moving mouse.
+            drawAndEmit(e);
           }
         });
 
@@ -142,7 +142,7 @@ angular.module('game').directive('dtDrawing', ['Socket', 'MouseConstants', 'Canv
          * Given a mouse event, update the last and cur values attached to
          * this element and perform the draw (as well as notifying the server)
          */
-        element.drawLine = function(e) {
+        var drawAndEmit = function(e) {
           if (!scope.Game.isDrawer(scope.username)) {
             return;
           }


### PR DESCRIPTION
Resolving [CMP-169](https://rolling-down-main-walkway.atlassian.net/browse/CMP-169) - eraser leaves white marks on canvas when it is selected. Unable to reproduce behaviour on own machine so asking @delete12 to verify.

Please checkout develop and compare behaviour to affirm fix of bug.
