### PR TITLE
Fix 'Game over!' being displayed when there is no game

### DIFF
--- a/modules/game/client/css/drawing.css
+++ b/modules/game/client/css/drawing.css
@@ -1,7 +1,7 @@
 .drawing-header {
   text-align: center;
-  font-size: 2em;
-  height: 2em;
+  font-size: 26px;
+  height: 52px; /* Set the height fixed so that elements below do not jump when content is loaded */
 }
 
 .dt-drawing {
@@ -15,4 +15,3 @@
 .dt-drawing-layer {
   position: absolute;
 }
-

--- a/modules/game/client/views/game.client.view.html
+++ b/modules/game/client/views/game.client.view.html
@@ -55,11 +55,11 @@
 
   <!-- The middle column -->
   <div class="col-md-5" >
-    <h3 class="drawing-header unselectable">
+    <div class="drawing-header unselectable">
       <span ng-if="Game.currentRound !== undefined && Game.numRounds !== undefined" ng-bind="Game.currentRound < Game.numRounds ? 'Round ' + (Game.currentRound + 1) + ':' : 'Game over!'"></span>
       <span ng-if="Game.getDrawers().length" ng-bind="Game.isDrawer(username) ? 'Draw &quot;' + topic + '&quot;' : Utils.toCommaListIs(Game.getDrawers()) + ' drawing'"></span>
       <button class="pull-right" ng-disabled="!Game.isDrawer(username) || Game.correctGuesses !== 0" ng-click="finishDrawing()">Give up</button>
-    </h3>
+    </div>
     <div class="dt-drawing"></div>
   </div>
 


### PR DESCRIPTION
Previously, the topic used to flash "Game over!" before the client received the Game from the server. Now, it will only display "Game over!" if the currentRound and numRounds are defined, which means that it has received the round information from the server.

Resolves [CMP-187](https://rolling-down-main-walkway.atlassian.net/browse/CMP-187)
