### PR TITLE
bugfix/moving toolbox

### DIFF
--- a/modules/game/client/controllers/game.client.controller.js
+++ b/modules/game/client/controllers/game.client.controller.js
@@ -371,6 +371,7 @@ angular.module('game').controller('GameController', ['$scope', '$location', '$do
 
       // Left column width is everything left over
       var spaceLeftOver = windowWidth - rightColumnWidth - middleColumn.offsetWidth;
+      spaceLeftOver -= 20; // magic padding for firefox (game container expands by 17px when you're not the drawer)
 
       // Rescale and redraw canvas contents
       if ($scope.canvas) {


### PR DESCRIPTION
- drawing toolbox doesn't jump to bottom anymore for shorter windows

How to test: (refer to [CMP-263](https://rolling-down-main-walkway.atlassian.net/browse/CMP-263))
- Height of body is 500-600 (ie not including the header bar), width can be anything
- Make sure the toolbox doesn't jump when:
  - pre-game: someone presses "start game"
  - in-game: someone's turn ends (timer ends, drawer presses "pass")
- don't use mobile view since that calls resize
  Note: bug was observed on firefox

Shoutout to Davy who found the solution
