### PR TITLE
bugfix/button fixes

### DIFF
--- a/modules/game/client/css/pregame.css
+++ b/modules/game/client/css/pregame.css
@@ -3,7 +3,7 @@
     text-align: center;
 }
 
-.amINonHost {
+.non-host {
     color: gray;
     opacity: 0.65;
 }

--- a/modules/game/client/views/game.client.view.html
+++ b/modules/game/client/views/game.client.view.html
@@ -61,7 +61,7 @@
     <h3 class="drawing-header unselectable">
       <span ng-bind="username === Game.getHost() ? 'You are' : Game.getHost() + ' is'"></span> choosing the game settings...
     </h3>
-    <div class="col-md-12" ng-class="{'amINonHost': Game.getHost() !== username}">
+    <div class="col-md-12" ng-class="{'non-host': Game.getHost() !== username}">
       <div class="pregame-group" ng-repeat="setting in Utils.keys(TopicSettings)" ng-init="value = TopicSettings[setting]">
         <h4><span ng-bind="value.settingName" class="unselectable"></span></h4>
         <div class="btn-group" ng-repeat="option in value.options">


### PR DESCRIPTION
- greyed out buttons for non-host in pregame settings (more obvious that they can't choose the settings) Note: cursor should still be fine (I deleted the .pregame-display{} from the css since it's not actually used)
- clear canvas button in drawing toolbox is pointer for drawer and default for non-drawer
