### PR TITLE
Always restart the server container to patch over avoid mongo connect…

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
   server:
     build:
       context: .
+    restart: always
     environment:
       NODE_ENV: production
       DB_1_PORT_27017_TCP_ADDR: mongodb


### PR DESCRIPTION
…ion errors

Not sure why the server fails to connect to mongo sometimes. I suspect it's because mongo doesn't start up in time. A "better" solution is to use a proper healthcheck on the mongo container and wait for that.